### PR TITLE
Patient Data for APM-E

### DIFF
--- a/data/patients/metabolic-antipsychotics/apme-2022-child-patient-1.json
+++ b/data/patients/metabolic-antipsychotics/apme-2022-child-patient-1.json
@@ -1,0 +1,1056 @@
+[
+  {
+    "resourceType": "Bundle",
+    "id": "adolescent-depression-bundle",
+    "type": "transaction",
+    "entry": [
+      {
+        "resource": {
+          "resourceType": "Patient",
+          "id": "patient-1",
+          "meta": {
+            "profile": [
+              "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+            ]
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+              "extension": [
+                {
+                  "url": "ombCategory",
+                  "valueCoding": {
+                    "system": "urn:oid:2.16.840.1.113883.6.238",
+                    "code": "2054-5",
+                    "display": "Black or African American"
+                  }
+                }
+              ]
+            },
+            {
+              "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+              "extension": [
+                {
+                  "url": "ombCategory",
+                  "valueCoding": {
+                    "system": "urn:oid:2.16.840.1.113883.6.238",
+                    "code": "2186-5",
+                    "display": "Not Hispanic or Latino"
+                  }
+                }
+              ]
+            }
+          ],
+          "identifier": [
+            {
+              "use": "usual",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "MR",
+                    "display": "Medical Record Number"
+                  }
+                ]
+              },
+              "system": "http://hospital.smarthealthit.org",
+              "value": "999999993"
+            }
+          ],
+          "name": [
+            {
+              "family": "Doe",
+              "given": [
+                "Jill"
+              ]
+            }
+          ],
+          "gender": "female",
+          "birthDate": "2007-07-29"
+        },
+        "request": {
+          "method": "PUT",
+          "url": "Patient/patient-1"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:9876B1",
+        "resource": {
+          "resourceType": "Coverage",
+          "id": "9876B1",
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the coverage</div>"
+          },
+          "identifier": [
+            {
+              "system": "http://benefitsinc.com/certificate",
+              "value": "12345"
+            }
+          ],
+          "status": "active",
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                "code": "RETIRE",
+                "display": "retiree health program"
+              },
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                "code": "DRUGPOL",
+                "display": "Drug Policy"
+              }
+            ]
+          },
+          "policyHolder": {
+            "reference": "http://benefitsinc.com/FHIR/Organization/CBI35"
+          },
+          "subscriber": {
+            "reference": "Patient/patient-1"
+          },
+          "beneficiary": {
+            "reference": "Patient/patient-1"
+          },
+          "dependent": "0",
+          "relationship": {
+            "coding": [
+              {
+                "code": "self"
+              }
+            ]
+          },
+          "period": {
+            "start": "2022-01-01",
+            "end": "2022-12-31"
+          },
+          "payor": [
+            {
+              "reference": "Organization/2"
+            }
+          ],
+          "class": [
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "group"
+                  }
+                ]
+              },
+              "value": "CB135",
+              "name": "Corporate Baker's Inc. Local #35"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "subgroup"
+                  }
+                ]
+              },
+              "value": "123",
+              "name": "Trainee Part-time Benefits"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "plan"
+                  }
+                ]
+              },
+              "value": "B37FC",
+              "name": "Full Coverage: Medical, Dental, Pharmacy, Vision, EHC"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "subplan"
+                  }
+                ]
+              },
+              "value": "P7",
+              "name": "Includes afterlife benefits"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "class"
+                  }
+                ]
+              },
+              "value": "SILVER",
+              "name": "Silver: Family Plan spouse only"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "subclass"
+                  }
+                ]
+              },
+              "value": "Tier2",
+              "name": "Low deductable, max $20 copay"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "sequence"
+                  }
+                ]
+              },
+              "value": "9"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "rxid"
+                  }
+                ]
+              },
+              "value": "MDF12345"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "rxbin"
+                  }
+                ]
+              },
+              "value": "987654"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "rxgroup"
+                  }
+                ]
+              },
+              "value": "M35PT"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "rxpcn"
+                  }
+                ]
+              },
+              "value": "234516"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                    "code": "sequence"
+                  }
+                ]
+              },
+              "value": "9"
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:phq-2",
+        "resource": {
+          "resourceType": "Observation",
+          "id": "phq-2",
+          "text": {
+            "status": "generated"
+          },
+          "status": "final",
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                  "code": "therapy",
+                  "display": "Therapy"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "version": "2.70.21AA",
+                "code": "2093-3",
+                "display": "Cholesterol [Mass/volume] in Serum or Plasma"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1"
+          },
+          "encounter": {
+            "reference": "Encounter/example"
+          },
+          "effectiveDateTime": "2022-02-28",
+          "valueInteger": 10
+        },
+        "request": {
+          "method": "POST",
+          "url": "Observation"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:phq-9",
+        "resource": {
+          "resourceType": "Observation",
+          "id": "phq-9",
+          "text": {
+            "status": "generated"
+          },
+          "status": "final",
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                  "code": "therapy",
+                  "display": "Therapy"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "version": "2.70.21AA",
+                "code": "2089-1",
+                "display": "Cholesterol in LDL [Mass/volume] in Serum or Plasma"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1"
+          },
+          "encounter": {
+            "reference": "Encounter/example"
+          },
+          "effectiveDateTime": "2022-03-28",
+          "valueInteger": 200
+        },
+        "request": {
+          "method": "POST",
+          "url": "Observation"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:phq-9",
+        "resource": {
+          "resourceType": "Observation",
+          "id": "phq-9",
+          "text": {
+            "status": "generated"
+          },
+          "status": "final",
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                  "code": "therapy",
+                  "display": "blood glucose measurement"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "313545000",
+                "display": "120 minute blood glucose measurement"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1"
+          },
+          "encounter": {
+            "reference": "Encounter/example"
+          },
+          "effectiveDateTime": "2022-04-28",
+          "valueInteger": 200
+        },
+        "request": {
+          "method": "POST",
+          "url": "Observation"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:phq-9",
+        "resource": {
+          "resourceType": "Observation",
+          "id": "phq-9",
+          "text": {
+            "status": "generated"
+          },
+          "status": "final",
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                  "code": "therapy",
+                  "display": "Hemoglobin A1c measurement"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "43396009",
+                "display": "Hemoglobin A1c measurement"
+              }
+            ]
+          },
+          "subject": {
+            "reference": "Patient/patient-1"
+          },
+          "encounter": {
+            "reference": "Encounter/example"
+          },
+          "effectiveDateTime": "2022-05-28",
+          "valueInteger": 200
+        },
+        "request": {
+          "method": "POST",
+          "url": "Observation"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:73a447f7-c7cd-ee4b-e007-4f4524458f1c",
+        "resource": {
+          "resourceType": "Procedure",
+          "id": "73a447f7-c7cd-ee4b-e007-4f4524458f1c",
+          "meta": {
+            "profile": [
+              "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+            ]
+          },
+          "status": "completed",
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "170935008",
+                "display": "Full care by hospice"
+              }
+            ],
+            "text": "Echocardiography (procedure)"
+          },
+          "subject": {
+            "reference": "urn:uuid:a300389f-259b-ee78-df91-971d28555fae"
+          },
+          "encounter": {
+            "reference": "urn:uuid:db742bac-c437-4ced-17c0-cd8efdd95423"
+          },
+          "performedPeriod": {
+            "start": "2022-02-25T19:59:51-05:00",
+            "end": "2022-02-25T20:14:51-05:00"
+          },
+          "location": {
+            "reference": "Location?identifier=https://github.com/synthetichealth/synthea|5ad4118a-3589-3537-9c3a-3e70ad4306d8",
+            "display": "BETH ISRAEL DEACONESS HOSPITAL-MILTON INC"
+          },
+          "reasonReference": [
+            {
+              "reference": "urn:uuid:20927316-2249-3760-c902-b389ec6db190",
+              "display": "Cardiac Arrest"
+            }
+          ]
+        },
+        "request": {
+          "method": "POST",
+          "url": "Procedure"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:phq-9",
+        "resource": {
+          "resourceType": "Claim",
+          "id": "760150",
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the Pharmacy Claim</div>"
+          },
+          "identifier": [
+            {
+              "system": "http://happypharma.com/claim",
+              "value": "7612345"
+            }
+          ],
+          "status": "active",
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+                "code": "pharmacy"
+              }
+            ]
+          },
+          "use": "claim",
+          "patient": {
+            "reference": "Patient/1"
+          },
+          "created": "2022-08-16",
+          "insurer": {
+            "reference": "Organization/2"
+          },
+          "provider": {
+            "reference": "Organization/1"
+          },
+          "priority": {
+            "coding": [
+              {
+                "code": "stat"
+              }
+            ]
+          },
+          "payee": {
+            "type": {
+              "coding": [
+                {
+                  "code": "provider"
+                }
+              ]
+            }
+          },
+          "careTeam": [
+            {
+              "sequence": 1,
+              "provider": {
+                "reference": "Practitioner/example"
+              }
+            }
+          ],
+          "diagnosis": [
+            {
+              "sequence": 1,
+              "diagnosisCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "654456"
+                  }
+                ]
+              }
+            }
+          ],
+          "insurance": [
+            {
+              "sequence": 1,
+              "focal": true,
+              "coverage": {
+                "reference": "Coverage/9876B1"
+              }
+            }
+          ],
+          "item": [
+            {
+              "sequence": 1,
+              "careTeamSequence": [
+                1
+              ],
+              "productOrService": {
+                "coding": [
+                  {
+                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                    "code": "314192"
+                  },
+                  {
+                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                    "version": "2021.03.01.20AB",
+                    "code": "198365",
+                    "display": "prochlorperazine 10 MG Oral Tablet"
+                  }
+                ]
+              },
+              "servicedDate": "2022-08-16",
+              "unitPrice": {
+                "value": 60.00,
+                "currency": "USD"
+              },
+              "net": {
+                "value": 60.00,
+                "currency": "USD"
+              }
+            }
+          ]
+        },
+        "request": {
+          "method": "POST",
+          "url": "Claim"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:phq-9",
+        "resource": {
+          "resourceType": "Claim",
+          "id": "760150",
+          "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">A human-readable rendering of the Pharmacy Claim</div>"
+          },
+          "identifier": [
+            {
+              "system": "http://happypharma.com/claim",
+              "value": "7612345"
+            }
+          ],
+          "status": "active",
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+                "code": "pharmacy"
+              }
+            ]
+          },
+          "use": "claim",
+          "patient": {
+            "reference": "Patient/1"
+          },
+          "created": "2022-08-16",
+          "insurer": {
+            "reference": "Organization/2"
+          },
+          "provider": {
+            "reference": "Organization/1"
+          },
+          "priority": {
+            "coding": [
+              {
+                "code": "stat"
+              }
+            ]
+          },
+          "payee": {
+            "type": {
+              "coding": [
+                {
+                  "code": "provider"
+                }
+              ]
+            }
+          },
+          "careTeam": [
+            {
+              "sequence": 1,
+              "provider": {
+                "reference": "Practitioner/example"
+              }
+            }
+          ],
+          "diagnosis": [
+            {
+              "sequence": 1,
+              "diagnosisCodeableConcept": {
+                "coding": [
+                  {
+                    "code": "654456"
+                  }
+                ]
+              }
+            }
+          ],
+          "insurance": [
+            {
+              "sequence": 1,
+              "focal": true,
+              "coverage": {
+                "reference": "Coverage/9876B1"
+              }
+            }
+          ],
+          "item": [
+            {
+              "sequence": 1,
+              "careTeamSequence": [
+                1
+              ],
+              "productOrService": {
+                "coding": [
+                  {
+                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                    "code": "314192"
+                  },
+                  {
+                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                    "version": "2021.03.01.20AB",
+                    "code": "198365",
+                    "display": "prochlorperazine 10 MG Oral Tablet"
+                  }
+                ]
+              },
+              "servicedDate": "2022-08-19",
+              "unitPrice": {
+                "value": 60.00,
+                "currency": "USD"
+              },
+              "net": {
+                "value": 60.00,
+                "currency": "USD"
+              }
+            }
+          ]
+        },
+        "request": {
+          "method": "POST",
+          "url": "Claim"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:encounter-1",
+        "resource": {
+          "resourceType": "Encounter",
+          "meta": {
+            "profile": [
+              "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"
+            ]
+          },
+          "id": "encounter-1",
+          "status": "finished",
+          "class": {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+            "code": "AMB"
+          },
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "https://www.nubc.org/CodeSystem/RevenueCodes",
+                  "version": "2012.05",
+                  "code": "0513",
+                  "display": "Psychiatric clinic"
+                }
+              ],
+              "text": "Psychiatric clinic Follow-up Visit"
+            }
+          ],
+          "diagnosis": [
+            {
+              "condition": {
+                "reference": "condition-3",
+                "display": "The patient is treated for a tumor"
+              },
+              "rank": 1
+            }
+          ],
+          "subject": {
+            "reference": "urn:uuid:96dcbd62-e4c6-a555-a663-77d08ad3c3b5",
+            "display": "Mr. Young120 Murphy561"
+          },
+          "period": {
+            "start": "2022-03-01T19:57:22-04:00",
+            "end": "2022-03-01T20:12:22-04:00"
+          },
+          "serviceProvider": {
+            "reference": "urn:uuid:275e5209-84ff-3ee7-bf02-d0e979877861",
+            "display": "LEXINGTON EYE ASSOCIATES, INC"
+          }
+        },
+        "request": {
+          "method": "POST",
+          "url": "Encounter"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-1",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-1",
+          "identifier": [
+            {
+              "value": "12345"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "55607006",
+                  "display": "Problem"
+                },
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "371596008",
+                "display": "Bipolar I disorder"
+              }
+            ]
+          },
+          "bodySite": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "38266002",
+                  "display": "Entire body as a whole"
+                }
+              ]
+            }
+          ],
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Roel"
+          },
+          "encounter": {
+            "reference": "Encounter/f201"
+          },
+          "onsetDateTime": "2021-04-02",
+          "abatementDateTime": "2021-04-09",
+          "recordedDate": "2021-04-02",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-2",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-2",
+          "identifier": [
+            {
+              "value": "12345"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "55607006",
+                  "display": "Problem"
+                },
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "192080009",
+                "display": "Chronic depression"
+              }
+            ]
+          },
+          "bodySite": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "38266002",
+                  "display": "Entire body as a whole"
+                }
+              ]
+            }
+          ],
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Roel"
+          },
+          "encounter": {
+            "reference": "Encounter/f201"
+          },
+          "onsetDateTime": "2021-04-02",
+          "abatementDateTime": "2021-04-09",
+          "recordedDate": "2021-04-02",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:condition-3",
+        "resource": {
+          "resourceType": "Condition",
+          "id": "condition-3",
+          "identifier": [
+            {
+              "value": "12345"
+            }
+          ],
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "55607006",
+                  "display": "Problem"
+                },
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "severity": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255604002",
+                "display": "Mild"
+              }
+            ]
+          },
+          "code": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "version": "2021.03.20AB",
+                "code": "191692007",
+                "display": "Active disintegrative psychoses"
+              }
+            ]
+          },
+          "bodySite": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "38266002",
+                  "display": "Entire body as a whole"
+                }
+              ]
+            }
+          ],
+          "subject": {
+            "reference": "Patient/patient-1",
+            "display": "Roel"
+          },
+          "encounter": {
+            "reference": "Encounter/f201"
+          },
+          "onsetDateTime": "2021-04-02",
+          "abatementDateTime": "2021-04-09",
+          "recordedDate": "2021-04-02",
+          "recorder": {
+            "reference": "Practitioner/f201"
+          },
+          "asserter": {
+            "reference": "Practitioner/f201"
+          }
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
# Related Tickets

<!-- If there is no Jira ticket for this PR, say why not. -->

- [SAR-318](https://jira.amida-tech.com/browse/SAR-318)

# How Things Worked (or Didn't) Before This PR

No data to test APM-E measure in CQL execution

# How Things Work Now (And How to Test)

Added 1 file in `data/patients/metabolic-antipsychotics/` for children and adolescents. Update `.env` to use `APME_HEDIS_MY2022-1.0.0` and run with `yarn localread`. Change data in either of the 2022 files.