### PR TITLE
[SAR-531]: Remove Valuesets from CQL Results

### DIFF
--- a/exec-files/exec-config.js
+++ b/exec-files/exec-config.js
@@ -171,6 +171,42 @@ const cleanData = patientResults => {
     // remove Patient data - not needed
     delete patient.Patient;
     patient.id = patientKey;
+
+    // Remove valuesets - not needed
+    switch(config.measurementType) {
+      case 'aab':
+      case 'cwp':
+      case 'uri':
+        delete patient['Outpatient Encounters'];
+        delete patient['Antibiotic Medication'];
+        delete patient['Comorbid Conditions Diagnosis'];
+        delete patient['Competing Condition Diagnosis'];
+
+        if (config.measurementType === 'aab') {
+          delete patient['Bronchitis Diagnosis']
+        } else if (config.measurementType === 'cwp') {
+          delete patient['Pharyngitis Diagnosis'];
+        } else if (config.measurementType === 'uri') {
+          delete patient['URI Diagnosis'];
+        }
+        break;
+      case 'apme':
+        delete patient['Antipsychotic Medication'];
+        break;
+      case 'cou':
+        delete patient['Opioid Medication Valuesets'];
+        break;
+      case 'fum':
+        delete patient['Mental Illness or Intentional Self-Harm'];
+        break;
+      case 'psa':
+        delete patient['PSA Lab Test Value Set'];
+        delete patient['PSA Lab Test Finding Value Set'];
+        break;
+      case 'uop':
+        delete patient['Opioid Medication Valuesets'];
+        break;
+    }
   });
   return clonedPatientResults;
 };

--- a/ncqa-test-validator-util.js
+++ b/ncqa-test-validator-util.js
@@ -110,7 +110,7 @@ const hedisData = {
             return (new Date(coverage.period.start.value).getTime()) <= currentDate
               && (new Date(coverage.period.end.value).getTime()) >= currentDate
           });
-        // If no coverages exists, expand the search to to full continuoous enrollment period
+        // If no coverages exists, expand the search to to full continuous enrollment period
         if (foundPayors.length === 0) {
           foundPayors = fullCoverageList
           .filter((coverage) => {
@@ -700,7 +700,7 @@ const hedisData = {
             return (new Date(coverage.period.start.value).getTime()) <= currentDate
               && (new Date(coverage.period.end.value).getTime()) >= currentDate
           });
-        // If no coverages exists, expand the search to to full continuoous enrollment period
+        // If no coverages exists, expand the search to to full continuous enrollment period
         if (foundPayors.length === 0) {
           foundPayors = fullCoverageList
           .filter((coverage) => {


### PR DESCRIPTION
# Related Tickets

<!-- If there is no Jira ticket for this PR, say why not. -->

- [SAR-531](https://amida.atlassian.net/browse/SAR-531)

# How Things Worked (or Didn't) Before This PR

Some measures, like AAB and COU, large datasets of medical codes are needed to search through. These valuesets are stored in the resulting json file creating a lot of unneeded data.

# How Things Work Now (And How to Test)

The specific fields for each measure type are removed making the json result smaller.